### PR TITLE
Configuration and Structure conversions

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements and configuration variables
         run: |

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -63,6 +63,7 @@ jobs:
           pip install CASMcode_global/dist/*.whl
           pip install CASMcode_crystallography/dist/*.whl
           pip install CASMcode_clexulator/dist/*.whl
+          pip install CASMcode_mapping/dist/*.whl
           pip install -r build_requirements.txt
           pip install -r test_requirements.txt
           echo "CASM_PREFIX=$(python -m libcasm.casmglobal --prefix)" >> "$GITHUB_ENV"

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -42,6 +42,14 @@ jobs:
           path: CASMcode_crystallography/dist
           key: ${{ runner.os }}-libcasm-xtal-v2-0a5
 
+      ### libcasm-mapping ###
+      - name: restore libcasm-mapping cache
+        id: cache-libcasm-mapping-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: CASMcode_mapping/dist
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache
         id: cache-libcasm-clexulator-restore

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a5
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a8
 
       ### libcasm-mapping ###
       - name: restore libcasm-mapping cache

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_clexulator/dist
-          key: ${{ runner.os }}-libcasm-clexulator-v2-0a2
+          key: ${{ runner.os }}-libcasm-clexulator-v2-0a3
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-linux-build.yml
+++ b/.github/workflows/test-linux-build.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_mapping/dist
-          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a2
 
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache

--- a/.github/workflows/test-linux-cxx-only.yml
+++ b/.github/workflows/test-linux-cxx-only.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-linux-cxx-only.yml
+++ b/.github/workflows/test-linux-cxx-only.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_clexulator/dist
-          key: ${{ runner.os }}-libcasm-clexulator-v2-0a2
+          key: ${{ runner.os }}-libcasm-clexulator-v2-0a3
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-linux-cxx-only.yml
+++ b/.github/workflows/test-linux-cxx-only.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a5
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a8
 
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a5
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a8
 
       - name: checkout libcasm-xtal
         if: steps.cache-libcasm-xtal-restore.outputs.cache-hit != 'true'
@@ -66,7 +66,7 @@ jobs:
         with:
           repository: prisms-center/CASMcode_crystallography
           path: CASMcode_crystallography
-          ref: v2.0a5
+          ref: v2.0a8
 
       - name: make xtal
         if: steps.cache-libcasm-xtal-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_clexulator/dist
-          key: ${{ runner.os }}-libcasm-clexulator-v2-0a2
+          key: ${{ runner.os }}-libcasm-clexulator-v2-0a3
 
       - name: checkout libcasm-clexulator
         if: steps.cache-libcasm-clexulator-restore.outputs.cache-hit != 'true'
@@ -99,7 +99,7 @@ jobs:
         with:
           repository: prisms-center/CASMcode_clexulator
           path: CASMcode_clexulator
-          ref: v2.0a2
+          ref: v2.0a3
 
       - name: make clexulator
         if: steps.cache-libcasm-clexulator-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -85,6 +85,39 @@ jobs:
           path: CASMcode_crystallography/dist
           key: ${{ steps.cache-libcasm-xtal-restore.outputs.cache-primary-key }}
 
+      ### libcasm-mapping ###
+      - name: restore libcasm-mapping cache
+        id: cache-libcasm-mapping-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: CASMcode_mapping/dist
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+
+      - name: checkout libcasm-mapping
+        if: steps.cache-libcasm-mapping-restore.outputs.cache-hit != 'true'
+        uses: actions/checkout@v3
+        with:
+          repository: prisms-center/CASMcode_mapping
+          path: CASMcode_mapping
+          ref: v2.0a1
+
+      - name: make mapping
+        if: steps.cache-libcasm-mapping-restore.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          cd CASMcode_mapping
+          python -m build
+          pip install dist/*.whl
+          pip install -r test_requirements.txt
+          python -m pytest -rsap python/tests
+
+      - name: save libcasm-mapping cache
+        id: cache-libcasm-mapping-save
+        uses: actions/cache/save@v3
+        with:
+          path: CASMcode_mapping/dist
+          key: ${{ steps.cache-libcasm-mapping-restore.outputs.cache-primary-key }}
+
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache
         id: cache-libcasm-clexulator-restore

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-linux-dependencies.yml
+++ b/.github/workflows/test-linux-dependencies.yml
@@ -91,7 +91,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_mapping/dist
-          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a2
 
       - name: checkout libcasm-mapping
         if: steps.cache-libcasm-mapping-restore.outputs.cache-hit != 'true'
@@ -99,7 +99,7 @@ jobs:
         with:
           repository: prisms-center/CASMcode_mapping
           path: CASMcode_mapping
-          ref: v2.0a1
+          ref: v2.0a2
 
       - name: make mapping
         if: steps.cache-libcasm-mapping-restore.outputs.cache-hit != 'true'

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -63,6 +63,7 @@ jobs:
           pip install CASMcode_global/dist/*.whl
           pip install CASMcode_crystallography/dist/*.whl
           pip install CASMcode_clexulator/dist/*.whl
+          pip install CASMcode_mapping/dist/*.whl
           pip install -r build_requirements.txt
           pip install -r test_requirements.txt
           echo "CASM_PREFIX=$(python -m libcasm.casmglobal --prefix)" >> "$GITHUB_ENV"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -42,6 +42,14 @@ jobs:
           path: CASMcode_crystallography/dist
           key: ${{ runner.os }}-libcasm-xtal-v2-0a5
 
+      ### libcasm-mapping ###
+      - name: restore libcasm-mapping cache
+        id: cache-libcasm-mapping-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: CASMcode_mapping/dist
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache
         id: cache-libcasm-clexulator-restore

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_crystallography/dist
-          key: ${{ runner.os }}-libcasm-xtal-v2-0a5
+          key: ${{ runner.os }}-libcasm-xtal-v2-0a8
 
       ### libcasm-mapping ###
       - name: restore libcasm-mapping cache

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_clexulator/dist
-          key: ${{ runner.os }}-libcasm-clexulator-v2-0a2
+          key: ${{ runner.os }}-libcasm-clexulator-v2-0a3
 
       - name: Install CASM dependencies
         run: |

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -48,7 +48,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: CASMcode_mapping/dist
-          key: ${{ runner.os }}-libcasm-mapping-v2-0a1
+          key: ${{ runner.os }}-libcasm-mapping-v2-0a2
 
       ### libcasm-clexulator ###
       - name: restore libcasm-clexulator cache

--- a/.github/workflows/test-macos-build.yml
+++ b/.github/workflows/test-macos-build.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.11'
 
       - name: Set up requirements & configuration variables
         run: |

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -6,4 +6,4 @@ ninja
 pybind11>=2.6
 libcasm-global>=2.0.2
 libcasm-xtal>=2.0a5
-libcasm-clexulator>=2.0a2
+libcasm-clexulator>=2.0a3

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -5,5 +5,5 @@ cmake>=3.20
 ninja
 pybind11>=2.6
 libcasm-global>=2.0.2
-libcasm-xtal>=2.0a6
+libcasm-xtal>=2.0a8
 libcasm-clexulator>=2.0a3

--- a/build_requirements.txt
+++ b/build_requirements.txt
@@ -5,5 +5,5 @@ cmake>=3.20
 ninja
 pybind11>=2.6
 libcasm-global>=2.0.2
-libcasm-xtal>=2.0a5
+libcasm-xtal>=2.0a6
 libcasm-clexulator>=2.0a3

--- a/include/casm/configuration/FromStructure.hh
+++ b/include/casm/configuration/FromStructure.hh
@@ -35,10 +35,13 @@ class SupercellSet;
 ///   all properties (including the coordinates, displacements,
 ///   and lattice vectors) are rotated so that they can be directly
 ///   copied to configuration DoF or properties.
-/// - Requires mapped_structure has global property "Ustrain",
-///   which is interpreted as the strain applied to the ideal
-///   lattice vectors to result in the structure's lattice vectors.
-/// - Solves L_mapped = Ustrain * L_ideal for L_ideal
+/// - If mapped_structure has a global strain property (i.e.
+///   "Ustrain", "Hstrain", "GLstrain", etc.) it must be of a type
+///   recognized by CASM; it is interpreted as the strain applied to
+///   the ideal lattice vectors to result in the structure's lattice
+///   vectors; and it is converted to "Ustrain".
+/// - Solves L_mapped = Ustrain * L_ideal for L_ideal, which must
+///   satisfy L_ideal == L_prim * T, where T is an integer matrix.
 ///
 class FromStructure {
  public:
@@ -100,15 +103,19 @@ class FromStructure {
 ///   all properties (including the coordinates, displacements,
 ///   and lattice vectors) are rotated so that they can be directly
 ///   copied to configuration DoF or properties.
-/// - Requires mapped_structure has global property "Ustrain",
-///   which is interpreted as the strain applied to the ideal
-///   lattice vectors to result in the structure's lattice vectors.
-/// - Solves L_mapped = Ustrain * L_ideal for L_ideal
+/// - If mapped_structure has a global strain property (i.e.
+///   "Ustrain", "Hstrain", "GLstrain", etc.) it must be of a type
+///   recognized by CASM; it is interpreted as the strain applied to
+///   the ideal lattice vectors to result in the structure's lattice
+///   vectors; and it is converted to "Ustrain".
+/// - Solves L_mapped = Ustrain * L_ideal for L_ideal, which must
+///   satisfy L_ideal == L_prim * T, where T is an integer matrix.
 /// - Atomic "disp" properties are the displacements from the ideal
 ///   site coordinates to the structure's atomic coordinates.
-/// - For global properties and DoF there is a complication:
-///   if a strain DoF exists, then Ustrain must be converted to the
-///   DoF strain metric
+/// - If a strain DoF exists, then the strain property of the mapped
+///   structure is converted to the DoF strain metric.
+/// - If a strain property does not exist, then it is assumed that
+///   there is no strain and the mapped_structure's lattice is ideal.
 ///
 class FromIsotropicAtomicStructure : public FromStructure {
  public:

--- a/include/casm/configuration/PrimSymInfo.hh
+++ b/include/casm/configuration/PrimSymInfo.hh
@@ -97,6 +97,8 @@ struct PrimSymInfo {
   /// - For each group element there is one matrix representation per sublattice
   /// - Local DoF values transform using these symrep matrices *before*
   ///   permuting among sites.
+  /// - If has_occupation_dofs==true, a matrix rep for transforming occupation
+  ///   indicator variables is included with key "occ".
   ///
   std::map<DoFKey, sym_info::LocalDoFSymGroupRep> local_dof_symgroup_rep;
 

--- a/include/casm/configuration/clusterography/orbits.hh
+++ b/include/casm/configuration/clusterography/orbits.hh
@@ -27,6 +27,21 @@ std::set<IntegralCluster> make_prim_periodic_orbit(
     IntegralCluster const &orbit_element,
     std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
 
+/// \brief Make equivalence map of factor group indices for an orbit of
+/// clusters,
+///     with periodic symmetry of a prim
+std::vector<std::vector<Index>> make_prim_periodic_equivalence_map_indices(
+    std::set<IntegralCluster> const &orbit,
+    std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
+
+/// \brief Make equivalence map for an orbit of clusters, with periodic
+///     symmetry of a prim
+std::vector<std::vector<xtal::SymOp>> make_prim_periodic_equivalence_map(
+    std::set<IntegralCluster> const &orbit,
+    std::shared_ptr<SymGroup const> const &symgroup,
+    Eigen::Matrix3d const &lat_column_mat,
+    std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
+
 /// \brief Return xtal::SymOp that leaves phenomenal invariant, and is a
 ///     combination of a factor group operation and a lattice translation
 xtal::SymOp make_cluster_group_element(
@@ -102,6 +117,19 @@ IntegralCluster local_integral_cluster_copy_apply(
 /// \brief Make an orbit of local clusters
 std::set<IntegralCluster> make_local_orbit(
     IntegralCluster const &orbit_element,
+    std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
+
+/// \brief Make equivalence map of phenomenal group indices for an orbit of
+/// local
+///     clusters
+std::vector<std::vector<Index>> make_local_equivalence_map_indices(
+    std::set<IntegralCluster> const &orbit,
+    std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
+
+/// \brief Make equivalence map for an orbit of local clusters
+std::vector<std::vector<xtal::SymOp>> make_local_equivalence_map(
+    std::set<IntegralCluster> const &orbit,
+    std::shared_ptr<SymGroup const> const &phenomenal_group,
     std::vector<xtal::UnitCellCoordRep> const &unitcellcoord_symgroup_rep);
 
 /// \brief Make groups that leave cluster orbit elements invariant

--- a/include/casm/configuration/irreps/VectorSpaceSymReport.hh
+++ b/include/casm/configuration/irreps/VectorSpaceSymReport.hh
@@ -10,6 +10,13 @@ namespace irreps {
 ///\brief Summary of data associated with the action of a symmetry group on a
 /// vector space
 struct VectorSpaceSymReport {
+  /// \brief Constructor
+  VectorSpaceSymReport(std::vector<Eigen::MatrixXd> _symgroup_rep,
+                       std::vector<IrrepInfo> _irreps,
+                       std::vector<SubWedge> _irreducible_wedge,
+                       Eigen::MatrixXd const &_symmetry_adapted_subspace,
+                       std::vector<std::string> _axis_glossary);
+
   /// \brief Matrix representation for each operation in the group -- defines
   /// action of group on vector space
   std::vector<Eigen::MatrixXd> symgroup_rep;
@@ -17,6 +24,30 @@ struct VectorSpaceSymReport {
   /// \brief A list of all irreducible representation that make up the full
   /// representation
   std::vector<IrrepInfo> irreps;
+
+  /// \brief Names for the irreps
+  ///
+  /// Form is "irrep_{i}_{j}", where:
+  /// - i: irrep group index (starting from 1) distinguishing groups of
+  /// identical irreps
+  ///   (irreps are identical if they have the same character vectors)
+  /// - j: equiv irrep index (starting from 1) distinguishing irreps with the
+  /// same
+  ///   character vectors
+  std::vector<std::string> irrep_names;
+
+  /// \brief Indices of columns in symmetry_adapted_subspace corresponding to
+  /// each irrep
+  ///
+  /// Column c = this->irrep_axes_indices[i][j]: is the column index (starting
+  /// with 0) in symmetry_adapted_subspace corresponding to the j-th dim of
+  /// this->irreps[i]
+  std::vector<std::vector<Index>> irrep_axes_indices;
+
+  /// \brief Irreducible wedge axes in the full vector space by irrep
+  ///
+  /// irrep_wedge_axes[i] corresponds to the wedge for this->irreps[i]
+  std::vector<Eigen::MatrixXd> irrep_wedge_axes;
 
   /// \brief Irreducible wedge in the vector space
   /// encoded as a vector of symmetrically distinct SubWedges
@@ -33,7 +64,8 @@ struct VectorSpaceSymReport {
 
 /// Construct VectorSpaceSymReport
 VectorSpaceSymReport vector_space_sym_report(
-    IrrepDecomposition const &irrep_decomposition, bool calc_wedges = false);
+    IrrepDecomposition const &irrep_decomposition, bool calc_wedges = false,
+    std::optional<std::vector<std::string>> axis_glossary = std::nullopt);
 
 }  // namespace irreps
 }  // namespace CASM

--- a/include/casm/configuration/make_simple_structure.hh
+++ b/include/casm/configuration/make_simple_structure.hh
@@ -15,12 +15,25 @@ class SimpleStructure;
 namespace config {
 
 struct Configuration;
+struct ConfigurationWithProperties;
 
 /// \brief Convert a Configuration to a SimpleStructure
 xtal::SimpleStructure make_simple_structure(
     Configuration const &configuration,
     std::map<std::string, Eigen::MatrixXd> const &local_properties = {},
     std::map<std::string, Eigen::VectorXd> const &global_properties = {});
+
+/// \brief Construct a SimpleStructure from a configuration of a Prim with
+///     atomic occupants
+class ToAtomicStructure {
+ public:
+  /// \brief Constructor
+  ToAtomicStructure();
+
+  /// \brief Convert a Configuration to a SimpleStructure
+  xtal::SimpleStructure operator()(
+      ConfigurationWithProperties const &configuration_with_properties);
+};
 
 }  // namespace config
 }  // namespace CASM

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ requires = [
     "pybind11>=2.6",
     "libcasm-global>=2.0.2",
     "libcasm-xtal>=2.0a5",
-    "libcasm-clexulator>=2.0a2",
+    "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -32,7 +32,7 @@ classifiers = [
 dependencies = [
   "libcasm-global>=2.0.2",
   "libcasm-xtal>=2.0a5",
-  "libcasm-clexulator>=2.0a2",
+  "libcasm-clexulator>=2.0a3",
   "numpy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ skip =  "pp*"
 before-build = "pip install -r build_requirements.txt"
 
 # Testing
-test-requires = "pytest pytest-datadir sortedcontainers libcasm-mapping>=2.0a1"
+test-requires = "pytest pytest-datadir sortedcontainers libcasm-mapping>=2.0a2"
 test-command = "pytest -rsap {project}/python/tests"
 
 [tool.cibuildwheel.macos]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "ninja",
     "pybind11>=2.6",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a5",
+    "libcasm-xtal>=2.0a6",
     "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "libcasm-global>=2.0.2",
-  "libcasm-xtal>=2.0a5",
+  "libcasm-xtal>=2.0a6",
   "libcasm-clexulator>=2.0a3",
   "numpy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
     "ninja",
     "pybind11>=2.6",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a6",
+    "libcasm-xtal>=2.0a8",
     "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"
@@ -31,7 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "libcasm-global>=2.0.2",
-  "libcasm-xtal>=2.0a6",
+  "libcasm-xtal>=2.0a8",
   "libcasm-clexulator>=2.0a3",
   "numpy",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ skip =  "pp*"
 before-build = "pip install -r build_requirements.txt"
 
 # Testing
-test-requires = "pytest pytest-datadir sortedcontainers"
+test-requires = "pytest pytest-datadir sortedcontainers libcasm-mapping>=2.0a1"
 test-command = "pytest -rsap {project}/python/tests"
 
 [tool.cibuildwheel.macos]

--- a/python/libcasm/clusterography/__init__.py
+++ b/python/libcasm/clusterography/__init__.py
@@ -30,8 +30,12 @@ from ._clusterography import (
     equivalents_info_from_dict,
     make_cluster_group,
     make_integral_site_coordinate_symgroup_rep,
+    make_local_equivalence_map,
+    make_local_equivalence_map_indices,
     make_local_orbit,
-    make_prim_periodic_orbit,
+    make_periodic_equivalence_map,
+    make_periodic_equivalence_map_indices,
+    make_periodic_orbit,
 )
 from ._methods import (
     make_local_cluster_specs,

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "pybind11>=2.8.0",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a6",
+    "libcasm-xtal>=2.0a8",
     "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -6,6 +6,6 @@ requires = [
     "pybind11>=2.8.0",
     "libcasm-global>=2.0.2",
     "libcasm-xtal>=2.0a5",
-    "libcasm-clexulator>=2.0a2",
+    "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -5,7 +5,7 @@ requires = [
     "wheel",
     "pybind11>=2.8.0",
     "libcasm-global>=2.0.2",
-    "libcasm-xtal>=2.0a5",
+    "libcasm-xtal>=2.0a6",
     "libcasm-clexulator>=2.0a3",
 ]
 build-backend = "setuptools.build_meta"

--- a/python/setup.py
+++ b/python/setup.py
@@ -108,7 +108,7 @@ setup(
         "pybind11",
         "libcasm-global>=2.0.2",
         "libcasm-xtal>=2.0a5",
-        "libcasm-clexulator>=2.0a2",
+        "libcasm-clexulator>=2.0a3",
     ],
     ext_modules=ext_modules,
     cmdclass={"build_ext": build_ext},

--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "pybind11",
         "libcasm-global>=2.0.2",
-        "libcasm-xtal>=2.0a6",
+        "libcasm-xtal>=2.0a8",
         "libcasm-clexulator>=2.0a3",
     ],
     ext_modules=ext_modules,

--- a/python/setup.py
+++ b/python/setup.py
@@ -107,7 +107,7 @@ setup(
     install_requires=[
         "pybind11",
         "libcasm-global>=2.0.2",
-        "libcasm-xtal>=2.0a5",
+        "libcasm-xtal>=2.0a6",
         "libcasm-clexulator>=2.0a3",
     ],
     ext_modules=ext_modules,

--- a/python/src/configuration.cpp
+++ b/python/src/configuration.cpp
@@ -194,6 +194,23 @@ PYBIND11_MODULE(_configuration, m) {
           },
           "Returns the crystal point group.")
       .def(
+          "has_occupation_dofs",
+          [](std::shared_ptr<config::Prim const> const &prim) {
+            return prim->sym_info.has_occupation_dofs;
+          },
+          R"pbdoc(
+          Returns True if >1 occupant allowed on any sublattice, False otherwise.
+          )pbdoc")
+      .def(
+          "has_anisotropic_occupants",
+          [](std::shared_ptr<config::Prim const> const &prim) {
+            return prim->sym_info.has_aniso_occs;
+          },
+          R"pbdoc(
+          Returns True if any permutation in :func:`Prim.occ_symgroup_rep` is
+          non-trivial, False otherwise.
+          )pbdoc")
+      .def(
           "global_dof_basis",
           [](std::shared_ptr<config::Prim const> const &prim, std::string key) {
             return prim->global_dof_info.at(key).basis();
@@ -255,6 +272,72 @@ PYBIND11_MODULE(_configuration, m) {
           },
           "Returns the symmetry group representation that describes how atom "
           "position indices transform under symmetry.")
+      .def(
+          "local_dof_matrix_rep",
+          [](std::shared_ptr<config::Prim const> const &prim, std::string key) {
+            return prim->sym_info.local_dof_symgroup_rep.at(key);
+          },
+          R"pbdoc(
+          Returns the symmetry group representation that describes how local "
+          continuous DoF transform under symmetry.
+
+          Notes
+          -----
+
+          - For each factor group element there is one matrix representation per
+            sublattice
+          - Local DoF values transform using these symrep matrices *before*
+            permuting among sites.
+          - If ``has_occupation_dofs() is True``, a matrix rep for transforming
+            occupation indicator variables is included with key "occ".
+
+
+          Parameters
+          ----------
+          key: str
+              Specifies the type of DoF
+
+          Returns
+          -------
+          local_dof_matrix_rep: list[list[numpy.ndarray[numpy.float64[m,m]]]]
+              The array ``local_dof_matrix_rep[factor_group_index][sublattice_index]``
+              is the matrix representation for transforming values of DoF `key`, in the
+              prim basis, on `sublattice_index`-th sublattice, by the
+              `factor_group_index`-th prim factor group operation.
+
+              Note that it is possible for the matrices associated with different
+              sublattices to be different sizes, including size zero, depending on the
+              corresponding :class:`~libcasm.xtal.DoFSetBasis`.
+          )pbdoc",
+          py::arg("key"))
+      .def(
+          "global_dof_matrix_rep",
+          [](std::shared_ptr<config::Prim const> const &prim, std::string key) {
+            return prim->sym_info.global_dof_symgroup_rep.at(key);
+          },
+          R"pbdoc(
+          Returns the symmetry group representation that describes how global "
+          continuous DoF transform under symmetry.
+
+          Notes
+          -----
+
+          - For each factor group element there is one matrix representation
+
+
+          Parameters
+          ----------
+          key: str
+              Specifies the type of DoF
+
+          Returns
+          -------
+          global_dof_matrix_rep: list[numpy.ndarray[numpy.float64[m,m]]]
+              The array ``global_dof_matrix_rep[factor_group_index]``
+              is the matrix representation for transforming values of DoF `key`, in the
+              prim basis, by the `factor_group_index`-th prim factor group operation.
+          )pbdoc",
+          py::arg("key"))
       .def_static(
           "from_json", &prim_from_json,
           "Construct a Prim from a JSON-formatted string. The `Prim reference "

--- a/python/src/configuration.cpp
+++ b/python/src/configuration.cpp
@@ -75,6 +75,11 @@ std::shared_ptr<config::Prim> make_prim(
 /// \brief Construct config::Prim from JSON string
 std::shared_ptr<config::Prim> prim_from_json(std::string const &prim_json_str,
                                              double xtal_tol) {
+  PyErr_WarnEx(PyExc_DeprecationWarning,
+               "libcasm.configuration.Prim.from_json() is deprecated. Use "
+               "xtal.Prim.from_dict() instead.",
+               2);
+
   jsonParser json = jsonParser::parse(prim_json_str);
   ParsingDictionary<AnisoValTraits> const *aniso_val_dict = nullptr;
   auto basicstructure = std::make_shared<xtal::BasicStructure>(
@@ -84,6 +89,11 @@ std::shared_ptr<config::Prim> prim_from_json(std::string const &prim_json_str,
 
 /// \brief Format xtal::BasicStructure as JSON string
 std::string prim_to_json(std::shared_ptr<config::Prim const> const &prim) {
+  PyErr_WarnEx(PyExc_DeprecationWarning,
+               "libcasm.configuration.Prim.to_json() is deprecated. Use "
+               "libcasm.configuration.Prim.xtal_prim().to_dict() instead.",
+               2);
+
   jsonParser json;
   write_prim(*prim->basicstructure, json, FRAC);
   std::stringstream ss;
@@ -338,18 +348,29 @@ PYBIND11_MODULE(_configuration, m) {
               prim basis, by the `factor_group_index`-th prim factor group operation.
           )pbdoc",
           py::arg("key"))
-      .def_static(
-          "from_json", &prim_from_json,
-          "Construct a Prim from a JSON-formatted string. The `Prim reference "
-          "<https://prisms-center.github.io/CASMcode_docs/formats/casm/"
-          "crystallography/BasicStructure/>`_ documents the expected JSON "
-          "format.",
-          py::arg("prim_json_str"), py::arg("xtal_tol") = TOL)
-      .def("to_json", &prim_to_json,
-           "Represent the Prim as a JSON-formatted string. The `Prim reference "
-           "<https://prisms-center.github.io/CASMcode_docs/formats/casm/"
-           "crystallography/BasicStructure/>`_ documents the expected JSON "
-           "format.");
+      .def_static("from_json", &prim_from_json,
+                  R"pbdoc(
+          Construct a Prim from a JSON-formatted string.
+
+          .. deprecated:: 2.0a2
+                Use :func:`libcasm.xtal.Prim.from_dict()` instead, then construct a
+                :class:`libcasm.configuration.Prim` instance.
+
+          The
+          `Prim reference <https://prisms-center.github.io/CASMcode_docs/formats/casm/crystallography/BasicStructure/>`_
+          documents the expected JSON format.
+          )pbdoc",
+                  py::arg("prim_json_str"), py::arg("xtal_tol") = TOL)
+      .def("to_json", &prim_to_json, R"pbdoc(
+          Represent the Prim as a JSON-formatted string.
+
+          .. deprecated:: 2.0a2
+                Use ``prim.xtal_prim().to_dict()`` instead.
+
+          The
+          `Prim reference <https://prisms-center.github.io/CASMcode_docs/formats/casm/crystallography/BasicStructure/>`_
+          documents the expected JSON format.
+          )pbdoc");
 
   // SupercellSet -- declare class
   py::class_<config::SupercellSet, std::shared_ptr<config::SupercellSet>>

--- a/python/src/configuration.cpp
+++ b/python/src/configuration.cpp
@@ -2923,7 +2923,7 @@ PYBIND11_MODULE(_configuration, m) {
       -------
       dof_space_rep: list[numpy.ndarray[numpy.float64[subspace_dim, subspace_dim]]]
           Elements, `M`, of `dof_space_rep` transform subspace vectors according to
-          ``x_subspace_after = M @ x_subspace_before`.
+          ``x_subspace_after = M @ x_subspace_before``.
 
       )pbdoc",
         py::arg("group"), py::arg("dof_space"));

--- a/python/src/irreps.cpp
+++ b/python/src/irreps.cpp
@@ -11,6 +11,8 @@
 #include "casm/configuration/irreps/IrrepDecomposition.hh"
 #include "casm/configuration/irreps/IrrepWedge.hh"
 #include "casm/configuration/irreps/VectorSpaceSymReport.hh"
+#include "casm/configuration/irreps/io/json/IrrepDecomposition_json_io.hh"
+#include "casm/configuration/irreps/io/json/VectorSpaceSymReport_json_io.hh"
 #include "pybind11_json/pybind11_json.hpp"
 
 #define STRINGIFY(x) #x
@@ -22,21 +24,6 @@ namespace py = pybind11;
 namespace CASMpy {
 
 using namespace CASM;
-
-irreps::VectorSpaceSymReport make_VectorSpaceSymReport(
-    std::vector<Eigen::MatrixXd> const &symgroup_rep,
-    std::vector<irreps::IrrepInfo> const &irreps,
-    std::vector<irreps::SubWedge> const &irreducible_wedge,
-    Eigen::MatrixXd const &symmetry_adapted_subspace,
-    std::vector<std::string> const &axis_glossary) {
-  irreps::VectorSpaceSymReport report;
-  report.symgroup_rep = symgroup_rep;
-  report.irreps = irreps;
-  report.irreducible_wedge = irreducible_wedge;
-  report.symmetry_adapted_subspace = symmetry_adapted_subspace;
-  report.axis_glossary = axis_glossary;
-  return report;
-}
 
 }  // namespace CASMpy
 
@@ -51,7 +38,8 @@ PYBIND11_MODULE(_irreps, m) {
         libcasm.irreps
         --------------
 
-        The libcasm.irreps package contains data structures and methods for finding irreducible space decompositions.
+        The libcasm.irreps package contains data structures and methods for finding
+        irreducible space decompositions.
 
     )pbdoc";
   py::module::import("libcasm.sym_info");
@@ -61,12 +49,15 @@ PYBIND11_MODULE(_irreps, m) {
             Describes an irreducible subspace.
             )pbdoc")
       .def(py::init<Eigen::MatrixXcd, Eigen::VectorXcd>(), R"pbdoc(
-          Construct IrrepInfo.
 
-          trans_mat : np.ndarray
-              An irrep_dim() x vector_dim() matrix that transforms a vector from the
-              initial vector space into a vector in the irreducible vector space.
-          characters : np.ndarray
+          .. rubric:: Constructor
+
+          Parameters
+          ----------
+          trans_mat : np.ndarray[np.float64[irrep_dim, vector_dim]]
+              A shape=(`irrep_dim`,`vector_dim`) matrix that transforms a vector from
+              the initial vector space into a vector in the irreducible vector space.
+          characters : numpy.ndarray[numpy.complex128[m, 1]]
               A vector containing the complex character of each group operation's
               action on the irreducible vector space.
           )pbdoc",
@@ -75,42 +66,65 @@ PYBIND11_MODULE(_irreps, m) {
                     "int: Irreducible subspace dimension")
       .def_readonly("vector_dim", &irreps::IrrepInfo::vector_dim,
                     "int: Vector space dimension")
-      .def_readonly(
-          "trans_mat", &irreps::IrrepInfo::trans_mat,
-          "np.ndarray: An irrep_dim() x vector_dim() matrix that transforms "
-          "a vector from the initial vector space into a vector in the "
-          "irreducible vector space")
-      .def_readonly(
-          "characters", &irreps::IrrepInfo::trans_mat,
-          "np.ndarray: An irrep_dim() x vector_dim() matrix that transforms "
-          "a vector from the initial vector space into a vector in the "
-          "irreducible vector space.")
+      .def_readonly("trans_mat", &irreps::IrrepInfo::trans_mat, R"pbdoc(
+          np.ndarray[np.float64[irrep_dim, vector_dim]]: A
+          shape=(`irrep_dim`,`vector_dim`) matrix that transforms a vector from the
+          initial vector space into a vector in the irreducible vector space.
+          )pbdoc")
+      .def_readonly("characters", &irreps::IrrepInfo::trans_mat, R"pbdoc(
+          numpy.ndarray[numpy.complex128[m, 1]]: A vector containing the complex
+          character of each group operation's action on the irreducible vector space.
+          )pbdoc")
       .def_readonly("directions", &irreps::IrrepInfo::directions,
                     R"pbdoc(
-      list[list[np.ndarray]]: High-symmetry directions
+          list[list[np.ndarray[np.float64[irrep_dim,]]]: High-symmetry directions
+
           Vectors in the initial vector space that correspond to high-symmetry
           directions in the irreducible vector space. ``directions[i]`` is the `i`-th
           orbit of equivalent high-symmetry directions and ``len(directions[i])`` is
           the symmetric multiplicity of a direction in that orbit.
-      )pbdoc");
+          )pbdoc")
+      .def(
+          "to_dict",
+          [](irreps::IrrepInfo const &self) -> nlohmann::json {
+            jsonParser json;
+            to_json(self, json);
+            return static_cast<nlohmann::json>(json);
+          },
+          R"pbdoc(
+          Represent the IrrepInfo as a Python dict.
+          )pbdoc");
 
   //
   py::class_<irreps::IrrepWedge>(m, "IrrepWedge", R"pbdoc(
       A wedge in an irreducible subspace
       )pbdoc")
       .def(py::init<irreps::IrrepInfo, Eigen::MatrixXd>(), R"pbdoc(
-          Construct IrrepWedge
-          )pbdoc",
-           py::arg("irrep_info"), py::arg("axes"))
-      .def_readonly(
-          "irrep_info", &irreps::IrrepWedge::irrep_info,
-          ":class:`~libcasm.irreps.IrrepInfo`: Irreducible space information")
-      .def_readonly("axes", &irreps::IrrepWedge::axes, R"pbdoc(
-          np.ndarray: High-symmetry axes
+
+          .. rubric: Constructor
+
+          Parameters
+          ----------
+          irrep_info: IrrepInfo
+              The :class:`IrrepInfo` of the irreducible subspace.
+          axes: numpy.ndarray[numpy.float64[vector_dim, irrep_dim]]
               Columns of `axes` are high-symmetry directions that form the edges
               of the irreducible wedge. The number of columns equals the
               dimension of the irreducible subspace. The number of rows is usually the
               fullspace dimension, but depending on context it could be a subspace."
+
+          )pbdoc",
+           py::arg("irrep_info"), py::arg("axes"))
+      .def_readonly("irrep_info", &irreps::IrrepWedge::irrep_info, R"pbdoc(
+          "IrrepInfo: Irreducible space information
+          )pbdoc")
+      .def_readonly("axes", &irreps::IrrepWedge::axes, R"pbdoc(
+          numpy.ndarray[numpy.float64[vector_dim, irrep_dim]]: High-symmetry axes
+
+          Columns of `axes` are high-symmetry directions that form the edges
+          of the irreducible wedge. The number of columns equals the
+          dimension of the irreducible subspace. The number of rows is usually the
+          fullspace dimension, but depending on context it could be a subspace."
           )pbdoc")
       .def_readonly(
           "mult", &irreps::IrrepWedge::mult,
@@ -125,49 +139,125 @@ PYBIND11_MODULE(_irreps, m) {
       the entire space. Then multiple SubWedge combine to fill the entire space.
       )pbdoc")
       .def(py::init<std::vector<irreps::IrrepWedge> const &>(), R"pbdoc(
-          Construct SubWedge
+
+          .. rubric:: Constructor
+
+          Parameters
+          ----------
+          irrep_wedges: list[IrrepWedge]
+              The :class:`IrrepWedge` that comprise the SubWedge
           )pbdoc",
            py::arg("irrep_wedges"))
-      .def_readonly("irrep_wedges", &irreps::SubWedge::irrep_wedges,
-                    "list[:class:`~libcasm.irreps.IrrepWedge`]: The IrrepWedge "
-                    "that comprise the SubWedge")
+      .def_readonly("irrep_wedges", &irreps::SubWedge::irrep_wedges, R"pbdoc(
+          "list[IrrepWedge]: The :class:`IrrepWedge` that comprise the SubWedge
+          )pbdoc")
       .def_readonly("trans_mat", &irreps::SubWedge::trans_mat, R"pbdoc(
-          np.ndarray:
-              Transformation matrix to convert from a vector in terms of the SubWedge
-              axes to a vector in the original vector space."
+          numpy.ndarray[numpy.float64[vector_dim, vector_dim]]: Transformation matrix
+          to convert from a vector in terms of the SubWedge axes to a vector in the
+          original vector space."
           )pbdoc");
 
   //
   py::class_<irreps::VectorSpaceSymReport>(m, "VectorSpaceSymReport",
                                            R"pbdoc(
-      Holds results from :func:`~libcasm.irreps.vector_space_sym_report`.
+      Holds results from irreducible space decompositions.
 
       )pbdoc")
-      .def(py::init(&make_VectorSpaceSymReport), R"pbdoc(
-           Construct a VectorSpaceSymReport.
-           )pbdoc",
-           py::arg("symgroup_rep"), py::arg("irreps"),
-           py::arg("irreducible_wedge"), py::arg("symmetry_adapted_subspace"),
-           py::arg("axis_glossary"))
-      .def_readonly(
-          "symgroup_rep", &irreps::VectorSpaceSymReport::symgroup_rep,
-          "list[np.ndarray]: The symmetry group representation matrices")
-      .def_readonly(
-          "irreps", &irreps::VectorSpaceSymReport::irreps,
-          "list[:class:`~libcasm.irreps.IrrepInfo`]: The irreducible subspaces")
-      .def_readonly(
-          "irreducible_wedge", &irreps::VectorSpaceSymReport::irreducible_wedge,
-          "list[:class:`~libcasm.irreps.SubWedge`]: The irreducible wedge "
-          "(if calculated)")
+      .def(
+          py::init<std::vector<Eigen::MatrixXd>, std::vector<irreps::IrrepInfo>,
+                   std::vector<irreps::SubWedge>, Eigen::MatrixXd const &,
+                   std::vector<std::string>>(),
+          R"pbdoc(
+
+          .. rubric:: Constructor
+
+          Parameters
+          ----------
+          symgroup_rep: list[numpy.ndarray[numpy.float64[vector_dim, vector_dim]]]
+              The symmetry group representation matrices
+          irreps: list[IrrepInfo]
+              The irreducible subspaces
+          irreducible_wedge: list[SubWedge]
+              The irreducible wedge, if calculated. Else, an empty list.
+          symmetry_adapted_subspace: numpy.ndarray[numpy.float64[vector_dim, subspace_dim]]
+              The symmetry adapted basis vectors, as a column vector matrix. The
+              number of columns, `subspace_dim` may be less than or equal to the full
+              dimension of the vector space, `vector_dim`.
+          axis_glossary:
+              Names given to individual axes in the initial vector space,
+              corresponding to rows of `symmetry_adapted_subspace`.
+          )pbdoc",
+          py::arg("symgroup_rep"), py::arg("irreps"),
+          py::arg("irreducible_wedge"), py::arg("symmetry_adapted_subspace"),
+          py::arg("axis_glossary"))
+      .def_readonly("symgroup_rep", &irreps::VectorSpaceSymReport::symgroup_rep,
+                    R"pbdoc(
+          list[numpy.ndarray[numpy.float64[vector_dim, vector_dim]]]: The symmetry "
+          group representation matrices
+          )pbdoc")
+      .def_readonly("irreps", &irreps::VectorSpaceSymReport::irreps, R"pbdoc(
+          list[IrrepInfo]: The irreducible subspaces
+          )pbdoc")
+      .def_readonly("irreducible_wedge",
+                    &irreps::VectorSpaceSymReport::irreducible_wedge,
+                    R"pbdoc(
+          list[SubWedge]: The irreducible wedge, if calculated. Else, an empty list.
+          )pbdoc")
       .def_readonly("symmetry_adapted_subspace",
                     &irreps::VectorSpaceSymReport::symmetry_adapted_subspace,
-                    "np.ndarray: The symmetry adapted basis vectors, as a "
-                    "column vector matrix")
-      .def_readonly(
-          "axis_glossary", &irreps::VectorSpaceSymReport::axis_glossary,
-          "list[str]: Names given to individual axes in initial (un-adapted) "
-          "vector "
-          "space, corresponding to rows of symmetry_adapted_subspace.");
+                    R"pbdoc(
+          numpy.ndarray[numpy.float64[vector_dim, subspace_dim]]: The symmetry adapted
+          basis vectors, as a column vector matrix. The number of columns,
+          `subspace_dim` may be less than or equal to the full dimension of the vector
+          space, `vector_dim`.
+          )pbdoc")
+      .def_readonly("axis_glossary",
+                    &irreps::VectorSpaceSymReport::axis_glossary, R"pbdoc(
+          list[str]: Names given to individual axes in initial vector space,
+          corresponding to rows of symmetry_adapted_subspace.
+          )pbdoc")
+      .def_readonly("irrep_names", &irreps::VectorSpaceSymReport::irrep_names,
+                    R"pbdoc(
+          list[str]: Names for the irreducible subspaces
+
+          The form of the names is `"irrep_{i}_{j}"`, where:
+
+          - `i`: The irrep group index (starting from 1) distinguishing groups of
+            identical irreps. Irreps are identical if they have the same
+            character vectors.
+          - `j`: The equivalent irrep index (starting from 1) distinguishing irreps
+            with the same character vectors.
+          )pbdoc")
+      .def_readonly("irrep_axes_indices",
+                    &irreps::VectorSpaceSymReport::irrep_axes_indices, R"pbdoc(
+          list[list[int]]: Indices of columns in :attr:`symmetry_adapted_subspace` \
+          corresponding to each irreducible subspace.
+
+          Given a :class:`VectorSpaceSymReport`, `report`, the column index
+          ``c = report.irrep_axes[i][j]`` is the column index (starting with 0)
+          in ``report.symmetry_adapted_subspace`` corresponding to the `j`-th dim
+          of ``report.irreps[i]`` (i.e. the `j`-th row of
+          ``report.irreps[i].trans_mat``).
+          )pbdoc")
+      .def_readonly("irrep_wedge_axes",
+                    &irreps::VectorSpaceSymReport::irrep_wedge_axes,
+                    R"pbdoc(
+          list[numpy.ndarray[numpy.float64[vector_dim, irrep_dim]]]: Irreducible \
+          wedge axes in the full vector space, by irreducible subspace
+
+          The matrix ``irrep_wedge_axes[i]`` are the axes for the wedge of the
+          `i`-th irreducible subspace, ``irreps[i]``.
+          )pbdoc")
+      .def(
+          "to_dict",
+          [](irreps::VectorSpaceSymReport const &self) -> nlohmann::json {
+            jsonParser json;
+            to_json(self, json);
+            return static_cast<nlohmann::json>(json);
+          },
+          R"pbdoc(
+          Represent the VectorSpaceSymReport as a Python dict."
+          )pbdoc");
 
 #ifdef VERSION_INFO
   m.attr("__version__") = MACRO_STRINGIFY(VERSION_INFO);

--- a/python/tests/clusterography/test_cluster.py
+++ b/python/tests/clusterography/test_cluster.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 import libcasm.clusterography as clust
+import libcasm.sym_info as sym_info
+import libcasm.xtal.prims as xtal_prims
 
 
 def test_cluster():
@@ -67,3 +69,49 @@ def test_cluster_translate_isub():
     translation = np.array([0, 0, 1])
     cluster -= translation
     assert cluster.to_list() == [[0, 1, 0, -1]]
+
+
+def test_cluster_compare():
+    # construct Cluster
+    A = clust.Cluster.from_list(
+        [
+            [0, 0, 0, 0],  # [b, i, j, k]
+            [0, 0, 1, 0],
+        ]
+    )
+    B = clust.Cluster.from_list(
+        [
+            [0, 0, 0, 0],  # [b, i, j, k]
+            [0, 1, 0, 0],
+        ]
+    )
+    assert A < B
+    assert A <= B
+    assert A <= A
+    assert B > A
+    assert B >= A
+    assert B >= B
+    assert A == A
+    assert B == B
+    assert A != B
+
+
+def test_cluster_rmul():
+    xtal_prim = xtal_prims.FCC(r=1.0, occ_dof=["A", "B", "Va"])
+    prim_factor_group = sym_info.make_factor_group(xtal_prim)
+    site_factor_group_rep = clust.make_integral_site_coordinate_symgroup_rep(
+        prim_factor_group.elements(), xtal_prim
+    )
+
+    # construct Cluster
+    cluster = clust.Cluster.from_list(
+        [
+            [0, 0, 0, 0],  # [b, i, j, k]
+            [0, 0, 1, 0],
+        ]
+    )
+    for site_rep in site_factor_group_rep:
+        transformed_cluster = site_rep * cluster
+        assert isinstance(transformed_cluster, clust.Cluster)
+        assert transformed_cluster.site(0) == site_rep * cluster.site(0)
+        assert transformed_cluster.site(1) == site_rep * cluster.site(1)

--- a/python/tests/clusterography/test_orbits.py
+++ b/python/tests/clusterography/test_orbits.py
@@ -1,0 +1,143 @@
+import libcasm.clusterography as clust
+import libcasm.sym_info as sym_info
+import libcasm.xtal as xtal
+import libcasm.xtal.prims as xtal_prims
+
+
+def test_make_periodic_orbit():
+    xtal_prim = xtal_prims.FCC(r=1.0, occ_dof=["A", "B", "Va"])
+    prim_factor_group = sym_info.make_factor_group(xtal_prim)
+    factor_group_site_rep = clust.make_integral_site_coordinate_symgroup_rep(
+        prim_factor_group.elements(), xtal_prim
+    )
+    cluster = clust.Cluster.from_list(
+        [
+            [0, 0, 0, 0],
+            [0, 1, 0, 0],
+        ]
+    )
+
+    ## Check orbit ##
+    orbit = clust.make_periodic_orbit(
+        orbit_element=cluster,
+        integral_site_coordinate_symgroup_rep=factor_group_site_rep,
+    )
+
+    assert len(orbit) == 6
+
+    ## Check equivalence map ##
+    equivalence_map = clust.make_periodic_equivalence_map(
+        orbit=orbit,
+        symgroup=prim_factor_group,
+        lattice=xtal_prim.lattice(),
+        integral_site_coordinate_symgroup_rep=factor_group_site_rep,
+    )
+
+    assert len(equivalence_map) == 6
+    prototype = orbit[0]
+    for i_equiv, eq_ops in enumerate(equivalence_map):
+        assert len(eq_ops) == 8
+        for i_op, op in enumerate(eq_ops):
+            _site_rep = xtal.IntegralSiteCoordinateRep(op, xtal_prim)
+            generated = (_site_rep * prototype).sorted()
+            assert isinstance(op, xtal.SymOp)
+            assert generated == orbit[i_equiv]
+
+    ## Check equivalence map indices ##
+    equivalence_map_indices = clust.make_periodic_equivalence_map_indices(
+        orbit=orbit,
+        integral_site_coordinate_symgroup_rep=factor_group_site_rep,
+    )
+
+    assert len(equivalence_map_indices) == 6
+    for i_equiv, eq_indices in enumerate(equivalence_map):
+        assert len(eq_indices) == 8
+
+    # fmt: off
+    expected = [
+      [0, 16, 18, 23, 25, 27, 32, 47],
+      [2, 7, 12, 19, 28, 33, 38, 42],
+      [1, 11, 14, 17, 26, 37, 40, 41],
+      [3, 6, 21, 22, 30, 31, 43, 46],
+      [4, 8, 9, 20, 29, 34, 35, 44],
+      [5, 10, 13, 15, 24, 36, 39, 45]
+    ]
+    # fmt: on
+
+    assert equivalence_map_indices == expected
+
+
+def test_make_local_orbit():
+    xtal_prim = xtal_prims.FCC(r=1.0, occ_dof=["A", "B", "Va"])
+    prim_factor_group = sym_info.make_factor_group(xtal_prim)
+    factor_group_site_rep = clust.make_integral_site_coordinate_symgroup_rep(
+        prim_factor_group.elements(), xtal_prim
+    )
+    phenomenal_cluster = clust.Cluster.from_list(
+        [
+            [0, 0, 0, 0],
+            [0, 1, 0, 0],
+        ]
+    )
+    phenomenal_group = clust.make_cluster_group(
+        cluster=phenomenal_cluster,
+        group=prim_factor_group,
+        lattice=xtal_prim.lattice(),
+        integral_site_coordinate_symgroup_rep=factor_group_site_rep,
+    )
+    assert len(phenomenal_group.elements()) == 8
+    phenomenal_group_site_rep = clust.make_integral_site_coordinate_symgroup_rep(
+        phenomenal_group.elements(), xtal_prim
+    )
+    assert len(phenomenal_group_site_rep) == 8
+
+    cluster = clust.Cluster.from_list(
+        [
+            [0, 0, 1, 0],
+        ]
+    )
+
+    ## Check orbit ##
+    orbit = clust.make_local_orbit(
+        orbit_element=cluster,
+        integral_site_coordinate_symgroup_rep=phenomenal_group_site_rep,
+    )
+    assert len(orbit) == 4
+
+    ## Check equivalence map ##
+    equivalence_map = clust.make_local_equivalence_map(
+        orbit=orbit,
+        phenomenal_group=phenomenal_group,
+        integral_site_coordinate_symgroup_rep=phenomenal_group_site_rep,
+    )
+
+    assert len(equivalence_map) == 4
+    prototype = orbit[0]
+    for i_equiv, eq_ops in enumerate(equivalence_map):
+        assert len(eq_ops) == 2
+        for i_op, op in enumerate(eq_ops):
+            _site_rep = xtal.IntegralSiteCoordinateRep(op, xtal_prim)
+            generated = (_site_rep * prototype).sorted()
+            assert isinstance(op, xtal.SymOp)
+            assert generated == orbit[i_equiv]
+
+    ## Check equivalence map indices ##
+    equivalence_map_indices = clust.make_local_equivalence_map_indices(
+        orbit=orbit,
+        integral_site_coordinate_symgroup_rep=phenomenal_group_site_rep,
+    )
+
+    assert len(equivalence_map_indices) == 4
+    for i_equiv, eq_indices in enumerate(equivalence_map):
+        assert len(eq_indices) == 2
+
+    # fmt: off
+    expected = [
+        [0, 5],
+        [3, 4],
+        [1, 6],
+        [2, 7],
+    ]
+    # fmt: on
+
+    assert equivalence_map_indices == expected

--- a/python/tests/configuration/test_config_space_analysis.py
+++ b/python/tests/configuration/test_config_space_analysis.py
@@ -43,6 +43,25 @@ def build_configurations_1(fcc_binary_prim: casmconfig.Prim):
     return configurations
 
 
+def expect_same_basis_vectors(basis, expected):
+    assert basis.shape == expected.shape
+    cols = basis.shape[1]
+    all_basis_vectors_found = True
+    for i in range(cols):
+        found = False
+        for j in range(cols):
+            if np.allclose(basis[:, i], expected[:, j]):
+                found = True
+                break
+        if found is False:
+            all_basis_vectors_found = False
+            break
+    if not all_basis_vectors_found:
+        print("basis:\n", basis)
+        print("expected:\n", expected)
+    assert all_basis_vectors_found
+
+
 def test_config_space_analysis_1(FCC_binary_prim):
     prim = casmconfig.Prim(FCC_binary_prim)
 
@@ -105,7 +124,7 @@ def test_config_space_analysis_1(FCC_binary_prim):
         ]
     ).transpose()
 
-    assert np.allclose(symmetry_adapted_dof_space.basis, expected)
+    expect_same_basis_vectors(symmetry_adapted_dof_space.basis, expected)
 
 
 def test_config_space_analysis_2(FCC_binary_prim):
@@ -172,7 +191,7 @@ def test_config_space_analysis_2(FCC_binary_prim):
         ]
     ).transpose()
 
-    assert np.allclose(symmetry_adapted_dof_space.basis, expected)
+    expect_same_basis_vectors(symmetry_adapted_dof_space.basis, expected)
 
 
 def test_config_space_analysis_3(FCC_binary_prim):
@@ -221,7 +240,7 @@ def test_config_space_analysis_3(FCC_binary_prim):
         ]
     ).transpose()
 
-    assert np.allclose(symmetry_adapted_dof_space.basis, expected)
+    expect_same_basis_vectors(symmetry_adapted_dof_space.basis, expected)
 
 
 def test_config_space_analysis_4(FCC_binary_prim):
@@ -270,4 +289,4 @@ def test_config_space_analysis_4(FCC_binary_prim):
         ]
     ).transpose()
 
-    assert np.allclose(symmetry_adapted_dof_space.basis, expected)
+    expect_same_basis_vectors(symmetry_adapted_dof_space.basis, expected)

--- a/python/tests/configuration/test_dof_space_analysis.py
+++ b/python/tests/configuration/test_dof_space_analysis.py
@@ -5,6 +5,51 @@ import libcasm.configuration as casmconfig
 import libcasm.irreps as casmirreps
 
 
+def conventional_FCC_occ_symmetry_adapted_basis():
+    # fmt: off
+    return np.array([
+        [ 0.,   0.,   0.,   0., ],
+        [-0.5, -0.5, -0.5, -0.5,],
+        [ 0.,   0.,   0.,   0., ],
+        [-0.5, -0.5,  0.5,  0.5,],
+        [ 0.,   0.,   0.,   0., ],
+        [-0.5,  0.5, -0.5,  0.5,],
+        [ 0.,   0.,   0.,   0., ],
+        [-0.5,  0.5,  0.5, -0.5,],
+    ])
+    # fmt: on
+
+
+def conventional_FCC_occ_irrep_1_wedge_axes():
+    # fmt: off
+    return np.array([
+        [ 0., ],
+        [-0.5,],
+        [ 0., ],
+        [-0.5,],
+        [ 0., ],
+        [-0.5,],
+        [ 0., ],
+        [-0.5,],
+    ])
+    # fmt: off
+
+
+def conventional_FCC_occ_irrep_2_wedge_axes():
+    # fmt: off
+    return np.array([
+        [ 0.,         0.,         0.,        ],
+        [-0.8660254, -0.5,       -0.28867513,],
+        [ 0.,         0.,         0.        ,],
+        [ 0.28867513, 0.5,       -0.28867513,],
+        [ 0.,         0.,         0.        ,],
+        [ 0.28867513, 0.5,        0.8660254 ,],
+        [ 0.,         0.,         0.        ,],
+        [ 0.28867513,-0.5,       -0.28867513,],
+    ])
+    # fmt: on
+
+
 def test_dof_space_analysis_1(FCC_binary_prim):
     prim = casmconfig.Prim(FCC_binary_prim)
     T_dof_space = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=int)
@@ -39,6 +84,9 @@ def test_dof_space_analysis_1(FCC_binary_prim):
         symmetry_adapted_dof_space.basis, sym_report.symmetry_adapted_subspace
     )
 
+    data = sym_report.to_dict()
+    assert isinstance(data, dict)
+
 
 def test_dof_space_analysis_2(FCC_binary_prim):
     prim = casmconfig.Prim(FCC_binary_prim)
@@ -67,11 +115,13 @@ def test_dof_space_analysis_2(FCC_binary_prim):
         # include_default_occ_modes=False,
         # sublattice_index_to_default_occ=None,
         # site_index_to_default_occ=None,
-        # calc_wedges=False,
+        calc_wedges=True,
     )
 
     symmetry_adapted_dof_space = results.symmetry_adapted_dof_space
     sym_report = results.symmetry_report
+
+    print(symmetry_adapted_dof_space.basis)
 
     assert len(sym_report.irreps) == 2
     assert sym_report.symmetry_adapted_subspace.shape[0] == 8
@@ -80,6 +130,13 @@ def test_dof_space_analysis_2(FCC_binary_prim):
     assert np.allclose(
         symmetry_adapted_dof_space.basis, sym_report.symmetry_adapted_subspace
     )
+
+    assert np.allclose(
+        symmetry_adapted_dof_space.basis, conventional_FCC_occ_symmetry_adapted_basis()
+    )
+
+    data = sym_report.to_dict()
+    assert isinstance(data, dict)
 
 
 def test_dof_space_analysis_2a(FCC_binary_prim):
@@ -169,6 +226,68 @@ def test_dof_space_analysis_2b(FCC_binary_prim):
 
     assert np.allclose(
         symmetry_adapted_dof_space.basis, sym_report.symmetry_adapted_subspace
+    )
+
+
+def test_dof_space_analysis_2c(FCC_binary_prim):
+    prim = casmconfig.Prim(FCC_binary_prim)
+    T_dof_space = np.array(
+        [  # conventional FCC cubic cell
+            [-1, 1, 1],
+            [1, -1, 1],
+            [1, 1, -1],
+        ],
+        dtype=int,
+    )
+
+    # construct occ DoFSpace with default basis
+    dof_space = casmclex.DoFSpace(
+        dof_key="occ",
+        xtal_prim=FCC_binary_prim,
+        transformation_matrix_to_super=T_dof_space,
+    )
+
+    # Perform DoF space analysis
+    results = casmconfig.dof_space_analysis(
+        dof_space=dof_space,
+        prim=prim,
+        # configuration=None,
+        # exclude_homogeneous_modes=None,
+        # include_default_occ_modes=False,
+        # sublattice_index_to_default_occ=None,
+        # site_index_to_default_occ=None,
+        calc_wedges=True,
+    )
+
+    symmetry_adapted_dof_space = results.symmetry_adapted_dof_space
+    sym_report = results.symmetry_report
+
+    assert len(sym_report.irreps) == 2
+    assert sym_report.symmetry_adapted_subspace.shape[0] == 8
+    assert sym_report.symmetry_adapted_subspace.shape[1] == 4
+
+    assert np.allclose(
+        symmetry_adapted_dof_space.basis, sym_report.symmetry_adapted_subspace
+    )
+
+    assert np.allclose(
+        symmetry_adapted_dof_space.basis, conventional_FCC_occ_symmetry_adapted_basis()
+    )
+
+    assert len(sym_report.irreducible_wedge) == 1
+
+    assert len(sym_report.irrep_names) == 2
+    assert sym_report.irrep_names == ["irrep_1_1", "irrep_2_1"]
+
+    assert len(sym_report.irrep_axes_indices) == 2
+    assert sym_report.irrep_axes_indices == [[0], [1, 2, 3]]
+
+    assert len(sym_report.irrep_wedge_axes) == 2
+    assert np.allclose(
+        sym_report.irrep_wedge_axes[0], conventional_FCC_occ_irrep_1_wedge_axes()
+    )
+    assert np.allclose(
+        sym_report.irrep_wedge_axes[1], conventional_FCC_occ_irrep_2_wedge_axes()
     )
 
 

--- a/python/tests/configuration/test_matrix_rep.py
+++ b/python/tests/configuration/test_matrix_rep.py
@@ -21,7 +21,6 @@ def test_conventional_fcc_matrix_rep(FCC_binary_GLstrain_disp_prim):
     site_indices = set(range(0, supercell.n_sites()))
 
     occ_rep = config.make_local_dof_matrix_rep(invariant_subgroup, "occ", site_indices)
-    # print(occ_rep)
     assert len(occ_rep) == 4 * 48
 
     disp_rep = config.make_local_dof_matrix_rep(

--- a/python/tests/configuration/test_prim.py
+++ b/python/tests/configuration/test_prim.py
@@ -15,7 +15,7 @@ def test_simple_cubic_binary_factor_group(simple_cubic_binary_prim):
     lattice = prim.xtal_prim().lattice()
     for op in prim.factor_group().elements():
         syminfo = xtal.SymInfo(op, lattice)
-        print(syminfo.to_json())
+        print(xtal.pretty_json(syminfo.to_dict()))
 
 
 def test_simple_cubic_binary_conjugacy_classes(simple_cubic_binary_prim):
@@ -34,13 +34,40 @@ def test_simple_cubic_binary_crystal_point_group(simple_cubic_binary_prim):
     assert len(prim.crystal_point_group().elements()) == 48
 
 
-def test_simple_cubic_binary_to_json(simple_cubic_binary_prim):
+def test_simple_cubic_binary_to_json_deprecated(simple_cubic_binary_prim):
     xtal_prim = simple_cubic_binary_prim
     prim = config.Prim(xtal_prim)
     prim_json = json.loads(prim.to_json())
     assert "basis" in prim_json
     assert "coordinate_mode" in prim_json
     assert "lattice_vectors" in prim_json
+
+
+def test_from_json_deprecated():
+    prim_json_str = """{
+        "basis": [{
+            "coordinate": [0.0, 0.0, 0.0],
+            "occupants": ["A", "B"]}
+        ],
+        "coordinate_mode": "Fractional",
+        "lattice_vectors": [
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0]
+        ],
+        "title": "prim"}"""
+    prim = config.Prim.from_json(prim_json_str)
+    assert prim.xtal_prim().coordinate_frac().shape == (3, 1)
+    assert len(prim.factor_group().elements()) == 48
+
+
+def test_simple_cubic_binary_to_json(simple_cubic_binary_prim):
+    xtal_prim = simple_cubic_binary_prim
+    prim = config.Prim(xtal_prim)
+    prim_data = json.dumps(prim.xtal_prim().to_dict())
+    assert "basis" in prim_data
+    assert "coordinate_mode" in prim_data
+    assert "lattice_vectors" in prim_data
 
 
 def test_from_json():
@@ -56,6 +83,7 @@ def test_from_json():
             [0.0, 0.0, 1.0]
         ],
         "title": "prim"}"""
-    prim = config.Prim.from_json(prim_json_str)
+    xtal_prim = xtal.Prim.from_dict(json.loads(prim_json_str))
+    prim = config.Prim(xtal_prim)
     assert prim.xtal_prim().coordinate_frac().shape == (3, 1)
     assert len(prim.factor_group().elements()) == 48

--- a/python/tests/configuration/test_structure_conversions.py
+++ b/python/tests/configuration/test_structure_conversions.py
@@ -1,0 +1,348 @@
+import numpy as np
+
+import libcasm.configuration as casmconfig
+import libcasm.mapping.info as mapinfo
+import libcasm.mapping.methods as mapmethods
+import libcasm.xtal as xtal
+import libcasm.xtal.prims as xtal_prims
+import libcasm.xtal.structures as xtal_structures
+
+
+def make_configuration(
+    supercell: casmconfig.Supercell,
+    occupation: list[int],
+):
+    config = casmconfig.Configuration(supercell)
+    config.set_occupation(occupation)
+    return config
+
+
+def make_unique_mapped_structures(
+    unmapped_structure: xtal.Structure,
+    structure_mappings: mapinfo.StructureMappingResults,
+    prim_factor_group: list[xtal.SymOp],
+) -> list[xtal.Structure]:
+    ### Find unique mapped structures
+    unique_mapped_structures = []
+    for i, smap in enumerate(structure_mappings):
+        # print(f"~~~ {i} ~~~")
+        # print(xtal.pretty_json(smap.to_dict()))
+        # print()
+
+        # Construct mapped_strucutre from structure mapping
+        mapped_structure = mapmethods.make_mapped_structure(
+            structure_mapping=smap,
+            unmapped_structure=unmapped_structure,
+        )
+
+        # Append symmetrically unique mapped structures to list
+        if len(unique_mapped_structures) == 0:
+            unique_mapped_structures.append(mapped_structure)
+            continue
+        found = False
+        for S in prim_factor_group:
+            transformed_mapped_structure = S * mapped_structure
+            if mapped_structure.is_equivalent_to(transformed_mapped_structure):
+                found = True
+                break
+        if not found:
+            unique_mapped_structures.append(mapped_structure)
+    return unique_mapped_structures
+
+
+def test_FCC_binary_prim_1(FCC_binary_prim):
+    prim = casmconfig.Prim(FCC_binary_prim)
+    T_prim = np.eye(3, dtype=int)
+    T_conventional = np.array(
+        [  # conventional FCC cubic cell
+            [-1, 1, 1],
+            [1, -1, 1],
+            [1, 1, -1],
+        ],
+        dtype=int,
+    )
+
+    ### FCC primitive cell ###
+
+    supercell = casmconfig.make_canonical_supercell(casmconfig.Supercell(prim, T_prim))
+    default_configuration = casmconfig.Configuration(supercell)
+
+    # convert Configuration to Structure
+    structure = default_configuration.to_structure()
+    assert structure.lattice() == supercell.superlattice()
+    assert np.allclose(
+        structure.atom_coordinate_cart(),
+        supercell.coordinate_cart(),
+    )
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert default_configuration.supercell() == in_configuration.supercell()
+    assert default_configuration == in_configuration
+
+    ### A ###
+    # set occupation and convert to Structure
+    configuration_A1 = make_configuration(supercell, [0])
+    structure = configuration_A1.to_structure()
+    assert structure.atom_type() == ["A"]
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert in_configuration.supercell() == supercell
+    assert in_configuration.occupation().tolist() == [0]
+
+    ### B ###
+    # set occupation and convert to Structure
+    configuration_B1 = make_configuration(supercell, [1])
+    structure = configuration_B1.to_structure()
+    assert structure.atom_type() == ["B"]
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert in_configuration.supercell() == supercell
+    assert in_configuration.occupation().tolist() == [1]
+
+    ### Conventional FCC unit cell ###
+    supercell = casmconfig.make_canonical_supercell(
+        casmconfig.Supercell(prim, T_conventional)
+    )
+    casmconfig.SupercellRecord(supercell)
+
+    # convert Configuration to Structure
+    default_configuration = casmconfig.Configuration(supercell)
+
+    # convert Configuration to Structure
+    structure = default_configuration.to_structure()
+    assert structure.lattice() == supercell.superlattice()
+    assert np.allclose(
+        structure.atom_coordinate_cart(),
+        supercell.coordinate_cart(),
+    )
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert default_configuration.supercell() == in_configuration.supercell()
+    assert default_configuration == in_configuration
+
+    ### A3B1 ###
+    # set occupation and convert to Structure
+    configuration_A3B1 = make_configuration(supercell, [1, 0, 0, 0])
+    structure = configuration_A3B1.to_structure()
+    assert structure.atom_type() == ["B", "A", "A", "A"]
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert in_configuration.supercell() == supercell
+    assert in_configuration.occupation().tolist() == [1, 0, 0, 0]
+
+    ### A1B3 ###
+    # set occupation and convert to Structure
+    configuration_A1B3 = make_configuration(supercell, [1, 1, 1, 0])
+    structure = configuration_A1B3.to_structure()
+    assert structure.atom_type() == ["B", "B", "B", "A"]
+
+    # read structure back in as a Configuration
+    in_configuration = casmconfig.Configuration.from_structure(
+        prim=prim,
+        structure=structure,
+    )
+    assert in_configuration.supercell() == supercell
+    assert in_configuration.occupation().tolist() == [1, 1, 1, 0]
+
+
+def test_bcc_hcp_mapping_conversions_1():
+    prim = xtal_prims.BCC(r=1.0, occ_dof=["A", "B", "Va"])
+    prim_factor_group = xtal.make_factor_group(prim)
+
+    hcp_structure = xtal_structures.HCP(r=1.0, atom_type="A")
+
+    ### Find structure mappings
+    # - this generates multiple equivalent mappings
+    structure_mappings = mapmethods.map_structures(
+        prim,
+        hcp_structure,
+        prim_factor_group=prim_factor_group,
+        max_vol=4,
+        max_cost=1e20,
+        min_cost=0.0,
+        k_best=1,
+    )
+
+    ### Find unique mapped structures
+    unique_mapped_structures = make_unique_mapped_structures(
+        unmapped_structure=hcp_structure,
+        structure_mappings=structure_mappings,
+        prim_factor_group=prim_factor_group,
+    )
+    assert len(unique_mapped_structures) == 1
+
+    ### Construct equivalent mapped structures
+    prototype_structure = unique_mapped_structures[0]
+    equivalent_mapped_structures = []
+    for S in prim_factor_group:
+        test = S * prototype_structure
+        found = False
+        for existing in equivalent_mapped_structures:
+            if test.is_equivalent_to(existing):
+                found = True
+                break
+        if not found:
+            equivalent_mapped_structures.append(test)
+
+    # print("### Equivalent mapped structures ###")
+    # for i, equiv in enumerate(equivalent_mapped_structures):
+    #     print(f"~~~ {i} ~~~")
+    #     print(xtal.pretty_json(equiv.to_dict()))
+    #     print()
+    assert len(equivalent_mapped_structures) == 12
+
+    ### Construct equivalent configuration in a Prim with strain and displacement DoF
+    BCC_strain_disp_prim = casmconfig.Prim(
+        xtal_prims.BCC(
+            r=1.0,
+            occ_dof=["A", "B", "Va"],
+            local_dof=[xtal.DoFSetBasis("disp")],
+            global_dof=[xtal.DoFSetBasis("Hstrain")],
+        )
+    )
+    mapped_configuration = casmconfig.make_canonical_configuration(
+        configuration=casmconfig.Configuration.from_structure(
+            prim=BCC_strain_disp_prim,
+            structure=prototype_structure,
+        ),
+        in_canonical_supercell=True,
+    )
+
+    ### Make the fully commensurate superdupercell
+    superduperlattice = xtal.make_superduperlattice(
+        lattices=[mapped_configuration.supercell().superlattice()],
+        mode="fully_commensurate",
+        point_group=BCC_strain_disp_prim.crystal_point_group().elements(),
+    )
+    T = xtal.make_transformation_matrix_to_super(
+        superlattice=superduperlattice,
+        unit_lattice=BCC_strain_disp_prim.xtal_prim().lattice(),
+    )
+    superdupercell = casmconfig.make_canonical_supercell(
+        casmconfig.Supercell(
+            prim=BCC_strain_disp_prim,
+            transformation_matrix_to_super=T,
+        ),
+    )
+
+    ### Put the mapped configuration into the fully commensurate superdupercell
+    prototype_configuration = casmconfig.copy_configuration(
+        motif=mapped_configuration,
+        supercell=superdupercell,
+    )
+
+    ### Generate equivalent configurations
+    equivalent_configurations = casmconfig.make_equivalent_configurations(
+        configuration=prototype_configuration,
+    )
+    # print("### Equivalent configurations ###")
+    # for i, equiv in enumerate(equivalent_configurations):
+    #     print(f"~~~ {i} ~~~")
+    #     print(xtal.pretty_json(equiv.to_dict()))
+    #     structure = equiv.to_structure()
+    #     print(xtal.pretty_json(structure.to_dict()))
+    #     print()
+    assert len(equivalent_configurations) == 12
+
+
+def test_bcc_hcp_mapping_conversions_2():
+    prim = xtal_prims.BCC(r=1.0, occ_dof=["A", "B", "Va"])
+    prim_factor_group = xtal.make_factor_group(prim)
+
+    _hcp_structure = xtal_structures.HCP(
+        r=1.0,
+        atom_type="A",
+        global_properties={"energy": np.array([[0.1]]).transpose()},
+    )
+    hcp_structure = xtal.Structure(
+        lattice=_hcp_structure.lattice(),
+        atom_coordinate_frac=_hcp_structure.atom_coordinate_frac(),
+        atom_type=["A", "B"],
+        global_properties=_hcp_structure.global_properties(),
+    )
+
+    ### Find structure mappings
+    # - this generates multiple equivalent mappings
+    structure_mappings = mapmethods.map_structures(
+        prim,
+        hcp_structure,
+        prim_factor_group=prim_factor_group,
+        max_vol=4,
+        max_cost=1e20,
+        min_cost=0.0,
+        k_best=1,
+    )
+
+    ### Find unique mapped structures
+    unique_mapped_structures = make_unique_mapped_structures(
+        unmapped_structure=hcp_structure,
+        structure_mappings=structure_mappings,
+        prim_factor_group=prim_factor_group,
+    )
+    assert len(unique_mapped_structures) == 1
+
+    ### Construct equivalent mapped structures
+    prototype_structure = unique_mapped_structures[0]
+    equivalent_mapped_structures = []
+    for S in prim_factor_group:
+        test = S * prototype_structure
+        found = False
+        for existing in equivalent_mapped_structures:
+            if test.is_equivalent_to(existing):
+                found = True
+                break
+        if not found:
+            equivalent_mapped_structures.append(test)
+
+    # print("### Equivalent mapped structures ###")
+    # for i, equiv in enumerate(equivalent_mapped_structures):
+    #     print(f"~~~ {i} ~~~")
+    #     print(xtal.pretty_json(equiv.to_dict()))
+    #     print()
+    assert len(equivalent_mapped_structures) == 12
+
+    ### Construct configuration with properties,
+    # including strain, displacement, and energy
+    BCC_prim = casmconfig.Prim(prim)
+
+    config_w_props = casmconfig.ConfigurationWithProperties.from_structure(
+        prim=BCC_prim,
+        structure=prototype_structure,
+    )
+    assert len(config_w_props.local_properties) == 1
+    assert "disp" in config_w_props.local_properties
+    assert len(config_w_props.global_properties) == 2
+    assert "energy" in config_w_props.global_properties
+    assert "Ustrain" in config_w_props.global_properties
+
+    # print("### Mapped configuration w/ properties ###")
+    # print(xtal.pretty_json(config_w_props.to_dict()))
+
+    ### Make canonical mapped configuration w/ properties
+    S = casmconfig.to_canonical_configuration(
+        configuration=config_w_props.configuration
+    )
+    S * config_w_props
+
+    # print("### Mapped canonical configuration w/ properties ###")
+    # print(xtal.pretty_json(canonical_config_w_props.to_dict()))

--- a/src/casm/configuration/Configuration.cc
+++ b/src/casm/configuration/Configuration.cc
@@ -34,7 +34,7 @@ bool Configuration::operator<(Configuration const &rhs) const {
 /// - Must have the same Prim
 /// - Checks that all DoF are the same, within tolerance
 bool Configuration::eq_impl(Configuration const &rhs) const {
-  if (supercell != rhs.supercell) {
+  if (*supercell != *rhs.supercell) {
     return false;
   }
   double xtal_tol = supercell->prim->basicstructure->lattice().tol();

--- a/src/casm/configuration/PrimSymInfo.cc
+++ b/src/casm/configuration/PrimSymInfo.cc
@@ -44,6 +44,18 @@ PrimSymInfo::PrimSymInfo(std::shared_ptr<SymGroup const> const &_factor_group,
 
   this->local_dof_symgroup_rep =
       make_local_dof_symgroup_rep(this->factor_group->element, prim);
+
+  if (this->has_occupation_dofs) {
+    local_dof_symgroup_rep["occ"] = sym_info::LocalDoFSymGroupRep();
+    for (sym_info::OccSymOpRep const &occ_symop_rep : this->occ_symgroup_rep) {
+      std::vector<Eigen::MatrixXd> occ_matrix_rep;
+      for (sym_info::Permutation const &perm : occ_symop_rep) {
+        occ_matrix_rep.push_back(sym_info::as_matrix(sym_info::inverse(perm)));
+      }
+      local_dof_symgroup_rep.at("occ").push_back(occ_matrix_rep);
+    }
+  }
+
   this->global_dof_symgroup_rep =
       make_global_dof_symgroup_rep(this->factor_group->element, prim);
 }

--- a/src/casm/configuration/SupercellSymOp.cc
+++ b/src/casm/configuration/SupercellSymOp.cc
@@ -660,26 +660,8 @@ std::vector<Eigen::MatrixXd> make_local_dof_matrix_rep(
   // - Local DoF values transform using these symrep matrices *before*
   //   permuting among sites.
 
-  sym_info::LocalDoFSymGroupRep local_dof_symgroup_rep;
-  if (key == "occ") {
-    // sym_info::Permutation perm =
-    //     occ_symgroup_rep.at(prim_fg_index).at(sublattice_index_before);
-    // convention is: occ_index_after = perm.at(occ_index_before)
-    // -> need to make permutation matrix using inverse(perm), P(perm[i],i)=1.0
-    // -> then, Eigen::VectorXd occ_indicator_after = P * occ_indicator_before;
-
-    sym_info::OccSymGroupRep const &occ_symgroup_rep =
-        prim.sym_info.occ_symgroup_rep;
-    for (sym_info::OccSymOpRep const &occ_symop_rep : occ_symgroup_rep) {
-      std::vector<Eigen::MatrixXd> occ_matrix_rep;
-      for (sym_info::Permutation const &perm : occ_symop_rep) {
-        occ_matrix_rep.push_back(sym_info::as_matrix(sym_info::inverse(perm)));
-      }
-      local_dof_symgroup_rep.push_back(occ_matrix_rep);
-    }
-  } else {
-    local_dof_symgroup_rep = prim.sym_info.local_dof_symgroup_rep.at(key);
-  }
+  sym_info::LocalDoFSymGroupRep local_dof_symgroup_rep =
+      prim.sym_info.local_dof_symgroup_rep.at(key);
   if (local_dof_symgroup_rep.size() == 0) {
     throw std::runtime_error(
         "Error in make_collective_dof_matrix_rep: DoF symgroup rep has "

--- a/src/casm/configuration/SupercellSymOp.cc
+++ b/src/casm/configuration/SupercellSymOp.cc
@@ -739,7 +739,8 @@ std::vector<Eigen::MatrixXd> make_local_dof_matrix_rep(
   }
 
   std::multiplies<SymOp> multiply_f;
-  xtal::SymOpPeriodicCompare_f equal_to_f(prim_lattice, xtal_tol);
+  xtal::SymOpPeriodicCompare_f equal_to_f(supercell.superlattice.superlattice(),
+                                          xtal_tol);
   symgroup = std::make_shared<SymGroup const>(
       group::make_group(element, multiply_f, equal_to_f));
 

--- a/src/casm/configuration/dof_space_analysis.cc
+++ b/src/casm/configuration/dof_space_analysis.cc
@@ -114,19 +114,14 @@ DoFSpaceAnalysisResults dof_space_analysis(
 
   bool allow_complex = true;
 
-  irreps::VectorSpaceSymReport symmetry_report;
-  try {
-    irreps::IrrepDecomposition irrep_decomposition(
-        matrix_rep, group_indices, dof_space.basis, make_cyclic_subgroups_f,
-        make_all_subgroups_f, allow_complex, log);
+  irreps::IrrepDecomposition irrep_decomposition(
+      matrix_rep, group_indices, dof_space.basis, make_cyclic_subgroups_f,
+      make_all_subgroups_f, allow_complex, log);
 
-    // Generate report, based on constructed inputs
-    symmetry_report = vector_space_sym_report(irrep_decomposition, calc_wedges);
+  // Generate report, based on constructed inputs
+  irreps::VectorSpaceSymReport symmetry_report = vector_space_sym_report(
+      irrep_decomposition, calc_wedges, dof_space.axis_info.glossary);
 
-  } catch (std::exception &e) {
-    CASM::err_log() << "Error in dof_space_analysis: " << e.what() << std::endl;
-    throw e;
-  }
   // check for error occuring for "disp"
   if (symmetry_report.symmetry_adapted_subspace.cols() <
       dof_space.basis.cols()) {

--- a/src/casm/configuration/irreps/Symmetrizer.cc
+++ b/src/casm/configuration/irreps/Symmetrizer.cc
@@ -95,7 +95,7 @@ multivector<Eigen::VectorXcd>::X<2> make_irrep_special_directions(
   } else {
     return make_irrep_special_directions(
         rep, head_group, irrep_subspace, vec_compare_tol,
-        make_cyclic_subgroups_f, make_cyclic_subgroups_f, true);
+        make_cyclic_subgroups_f, make_all_subgroups_f, true);
   }
 }
 

--- a/src/casm/configuration/irreps/VectorSpaceSymReport.cc
+++ b/src/casm/configuration/irreps/VectorSpaceSymReport.cc
@@ -1,33 +1,95 @@
 #include "casm/configuration/irreps/VectorSpaceSymReport.hh"
 
+#include "casm/misc/CASM_eigen_math.hh"
+
 namespace CASM {
 namespace irreps {
+
+/// \brief Constructor
+VectorSpaceSymReport::VectorSpaceSymReport(
+    std::vector<Eigen::MatrixXd> _symgroup_rep, std::vector<IrrepInfo> _irreps,
+    std::vector<SubWedge> _irreducible_wedge,
+    Eigen::MatrixXd const &_symmetry_adapted_subspace,
+    std::vector<std::string> _axis_glossary)
+    : symgroup_rep(std::move(_symgroup_rep)),
+      irreps(std::move(_irreps)),
+      irreducible_wedge(std::move(_irreducible_wedge)),
+      symmetry_adapted_subspace(_symmetry_adapted_subspace),
+      axis_glossary(std::move(_axis_glossary)) {
+  // ~~~ Identify irrep_names, irrep_axes_indices, irrep_wedges  ~~~
+  std::vector<Index> mults;
+  for (auto const &irrep : this->irreps) {
+    if (irrep.index == 0) mults.push_back(0);
+    mults.back()++;
+  }
+
+  Index NQ = this->symmetry_adapted_subspace.cols();
+  Index i = 0;  // irreps with unique characters index
+  Index l = 0;  // irrep index
+  Index q = 0;  // symmetry_adapted_subspace column index
+  for (Index mult : mults) {
+    ++i;
+    for (Index m = 0; m < mult; ++m) {  // irreps with same character index
+
+      // irrep_names
+      std::string irrep_name = "irrep_" +
+                               to_sequential_string(i, mults.size()) + "_" +
+                               to_sequential_string(m + 1, mult);
+      this->irrep_names.push_back(irrep_name);
+
+      // irrep_wedge_axes
+      auto const &irrep = this->irreps[l];
+      if (this->irreducible_wedge.size()) {
+        this->irrep_wedge_axes.push_back(
+            this->irreducible_wedge[0].irrep_wedges[l].axes);
+      }
+
+      // irrep_axes_indices
+      std::vector<Index> irrep_axes_indices;
+      for (Index a = 0; a < irrep.irrep_dim; ++a, ++q) {
+        irrep_axes_indices.push_back(q);
+      }
+      this->irrep_axes_indices.push_back(irrep_axes_indices);
+
+      // increment irrep index
+      ++l;
+    }
+  }
+}
 
 /// Construct VectorSpaceSymReport
 ///
 /// \param irrep_decomposition An IrrepDecomposition
 /// \param calc_wedges If true, 'irreducible_wedge' is constructed. If false,
 ///     'irreducible_wedge' is empty.
+/// \param axis_glossary If has value, copied to
+/// VectorSpaceSymReport.axis_glossary;
+///     otherwise, axis_glossary is set to {"x1", "x2", ...}
 VectorSpaceSymReport vector_space_sym_report(
-    IrrepDecomposition const &irrep_decomposition, bool calc_wedges) {
-  VectorSpaceSymReport result;
-  result.irreps = irrep_decomposition.irreps;
-  result.symmetry_adapted_subspace =
-      irrep_decomposition.symmetry_adapted_subspace;
+    IrrepDecomposition const &irrep_decomposition, bool calc_wedges,
+    std::optional<std::vector<std::string>> axis_glossary) {
+  std::vector<Eigen::MatrixXd> symgroup_rep;
   for (Index element_index : irrep_decomposition.head_group) {
-    auto matrix_rep = irrep_decomposition.fullspace_rep[element_index];
-    result.symgroup_rep.push_back(matrix_rep);
+    symgroup_rep.push_back(irrep_decomposition.fullspace_rep[element_index]);
   }
-  result.axis_glossary =
-      std::vector<std::string>(result.symmetry_adapted_subspace.rows(), "x");
-  Index i = 0;
-  for (std::string &x : result.axis_glossary) {
-    x += std::to_string(++i);
+
+  if (!axis_glossary.has_value()) {
+    axis_glossary = std::vector<std::string>(
+        irrep_decomposition.symmetry_adapted_subspace.rows(), "x");
+    Index i = 0;
+    for (std::string &x : axis_glossary.value()) {
+      x += std::to_string(++i);
+    }
   }
+
+  std::vector<SubWedge> irreducible_wedge;
   if (calc_wedges) {
-    result.irreducible_wedge = make_symrep_subwedges(irrep_decomposition);
+    irreducible_wedge = make_symrep_subwedges(irrep_decomposition);
   }
-  return result;
+
+  return VectorSpaceSymReport(
+      symgroup_rep, irrep_decomposition.irreps, irreducible_wedge,
+      irrep_decomposition.symmetry_adapted_subspace, axis_glossary.value());
 }
 
 }  // namespace irreps

--- a/src/casm/configuration/irreps/io/json/VectorSpaceSymReport_json_io.cc
+++ b/src/casm/configuration/irreps/io/json/VectorSpaceSymReport_json_io.cc
@@ -14,6 +14,21 @@ namespace irreps {
 jsonParser &to_json(VectorSpaceSymReport const &obj, jsonParser &json) {
   json["symmetry_representation"] = obj.symgroup_rep;
 
+  json["symmetry_adapted_subspace"] = obj.symmetry_adapted_subspace.transpose();
+
+  json["irrep_names"] = obj.irrep_names;
+
+  json["irrep_axes_indices"] = obj.irrep_axes_indices;
+
+  if (obj.irreducible_wedge.size()) {
+    json["irrep_wedge_axes"].put_obj();
+    for (Index i = 0; i < obj.irrep_names.size(); ++i) {
+      std::string irrep_name = obj.irrep_names[i];
+      json["irrep_wedge_axes"][irrep_name] =
+          obj.irrep_wedge_axes[i].transpose();
+    }
+  }
+
   json["glossary"] = obj.axis_glossary;
 
   std::vector<Index> mults;

--- a/src/casm/configuration/make_simple_structure.cc
+++ b/src/casm/configuration/make_simple_structure.cc
@@ -1,3 +1,5 @@
+#include "casm/configuration/make_simple_structure.hh"
+
 #include "casm/clexulator/ConfigDoFValuesTools_impl.hh"
 #include "casm/configuration/Configuration.hh"
 #include "casm/crystallography/SimpleStructure.hh"
@@ -34,7 +36,6 @@ namespace config {
 ///   1) a strain DoF (this is not copied to structure.properties)
 ///   2) "Ustrain" in global_properties (this is copied to structure.properties)
 ///   3) the identify matrix, I
-/// -
 xtal::SimpleStructure make_simple_structure(
     Configuration const &configuration,
     std::map<std::string, Eigen::MatrixXd> const &local_properties,
@@ -146,6 +147,43 @@ xtal::SimpleStructure make_simple_structure(
 
   structure.deform_coords(F);
   return structure;
+}
+
+/// \brief Constructor
+ToAtomicStructure::ToAtomicStructure() {}
+
+/// \brief Convert a Configuration to a SimpleStructure
+///
+/// \param configuration_with_properties The configuration being
+///     converted to a SimpleStructure along with local and
+///     global properties.
+/// \returns simple_structure A SimpleStructure representation
+///     of the configuration
+///
+/// Notes:
+/// - This is a simpler method which accepts configurations from
+///   prim with only atomic occupants
+/// - Deformation gradient applied to ideal lattice vectors to
+///   generate the resulting structure's lattice is obtained from:
+///   1) a strain DoF (this is not copied to structure.properties)
+///   2) "Ustrain" in global_properties (this is copied to
+///      structure.properties)
+///   3) the identify matrix, I
+/// - If "disp" is a DoF, it is included in
+///   SimpleStructure::atom_info.coords, but not included
+///   in SimpleStructure::atom_info.properties.
+/// - If strain is a DoF, it is included in
+///   SimpleStructure::atom_info.coords and
+///   SimpleStructure::lat_column_mat, but not included in
+///   SimpleStructure::properties.
+/// - Other DoF are copied to
+///   SimpleStructure::atom_info.properties or
+///   SimpleStructure::properties.
+xtal::SimpleStructure ToAtomicStructure::operator()(
+    ConfigurationWithProperties const &configuration_with_properties) {
+  auto const &x = configuration_with_properties;
+  return make_simple_structure(x.configuration, x.local_properties,
+                               x.global_properties);
 }
 
 }  // namespace config

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-datadir
 sortedcontainers
+libcasm-mapping>=2.0a1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
 pytest
 pytest-datadir
 sortedcontainers
-libcasm-mapping>=2.0a1
+libcasm-mapping>=2.0a2

--- a/tests/unit/configuration/PrimSymInfo_test.cpp
+++ b/tests/unit/configuration/PrimSymInfo_test.cpp
@@ -19,7 +19,7 @@ TEST(PrimSymInfoTest, Test1) {
   EXPECT_EQ(prim_sym_info.occ_symgroup_rep.size(), 48);
   EXPECT_EQ(prim_sym_info.atom_position_symgroup_rep.size(), 48);
   EXPECT_EQ(prim_sym_info.has_aniso_occs, false);
-  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim_sym_info.global_dof_symgroup_rep.size(), 0);
 }
 
@@ -32,7 +32,7 @@ TEST(PrimSymInfoTest, Test2) {
   EXPECT_EQ(prim_sym_info.occ_symgroup_rep.size(), 96);
   EXPECT_EQ(prim_sym_info.atom_position_symgroup_rep.size(), 96);
   EXPECT_EQ(prim_sym_info.has_aniso_occs, true);
-  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim_sym_info.global_dof_symgroup_rep.size(), 0);
 }
 
@@ -45,7 +45,7 @@ TEST(PrimSymInfoTest, Test3) {
   EXPECT_EQ(prim_sym_info.occ_symgroup_rep.size(), 48);
   EXPECT_EQ(prim_sym_info.atom_position_symgroup_rep.size(), 48);
   EXPECT_EQ(prim_sym_info.has_aniso_occs, false);
-  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim_sym_info.global_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim_sym_info.global_dof_symgroup_rep.at("GLstrain").size(), 48);
 }
@@ -92,6 +92,6 @@ TEST(PrimSymInfoTest, Test5) {
   }
 
   EXPECT_EQ(prim_sym_info.has_aniso_occs, true);
-  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim_sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim_sym_info.global_dof_symgroup_rep.size(), 0);
 }

--- a/tests/unit/configuration/Prim_test.cpp
+++ b/tests/unit/configuration/Prim_test.cpp
@@ -14,7 +14,7 @@ TEST(PrimTest, Test1) {
   EXPECT_EQ(prim->sym_info.unitcellcoord_symgroup_rep.size(), 48);
   EXPECT_EQ(prim->sym_info.occ_symgroup_rep.size(), 48);
   EXPECT_EQ(prim->sym_info.has_aniso_occs, false);
-  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim->sym_info.global_dof_symgroup_rep.size(), 0);
 }
 
@@ -27,7 +27,7 @@ TEST(PrimTest, Test2) {
   EXPECT_EQ(prim->sym_info.unitcellcoord_symgroup_rep.size(), 96);
   EXPECT_EQ(prim->sym_info.occ_symgroup_rep.size(), 96);
   EXPECT_EQ(prim->sym_info.has_aniso_occs, true);
-  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim->sym_info.global_dof_symgroup_rep.size(), 0);
 }
 
@@ -40,7 +40,7 @@ TEST(PrimTest, Test3) {
   EXPECT_EQ(prim->sym_info.unitcellcoord_symgroup_rep.size(), 48);
   EXPECT_EQ(prim->sym_info.occ_symgroup_rep.size(), 48);
   EXPECT_EQ(prim->sym_info.has_aniso_occs, false);
-  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 0);
+  EXPECT_EQ(prim->sym_info.local_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim->sym_info.global_dof_symgroup_rep.size(), 1);
   EXPECT_EQ(prim->sym_info.global_dof_symgroup_rep.at("GLstrain").size(), 48);
 }

--- a/tests/unit/configuration/config_space_analysis_test.cpp
+++ b/tests/unit/configuration/config_space_analysis_test.cpp
@@ -75,6 +75,28 @@ class ConfigSpaceAnalysisTest : public testing::Test {
     }
   }
 
+  void expect_same_basis_vectors(Eigen::MatrixXd const &basis,
+                                 Eigen::MatrixXd const &expected) {
+    EXPECT_EQ(basis.cols(), expected.cols());
+    bool all_basis_vectors_found = true;
+    for (Index c_basis = 0; c_basis < basis.cols(); ++c_basis) {
+      bool found = false;
+      for (Index c_expected = 0; c_expected < expected.cols(); ++c_expected) {
+        if (almost_equal(basis.col(c_basis), expected.col(c_expected))) {
+          found = true;
+          break;
+        }
+      }
+      if (!found) {
+        all_basis_vectors_found = false;
+        break;
+      }
+    }
+    EXPECT_TRUE(all_basis_vectors_found) << "basis: \n"
+                                         << basis << "\nexpected: \n"
+                                         << expected << std::endl;
+  }
+
   std::shared_ptr<xtal::BasicStructure const> xtal_prim;
   std::shared_ptr<config::Prim const> prim;
 
@@ -127,7 +149,7 @@ TEST_F(ConfigSpaceAnalysisTest, Test1) {
   expected.col(2) << 0.0, -sqrt(3.) / 2., 0.0, sqrt(3.) / 6., 0.0,
       sqrt(3.) / 6., 0.0, sqrt(3.) / 6.;
   expected.col(3) << 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5;
-  EXPECT_TRUE(almost_equal(basis, expected));
+  expect_same_basis_vectors(basis, expected);
 }
 
 TEST_F(ConfigSpaceAnalysisTest, Test2) {
@@ -165,7 +187,7 @@ TEST_F(ConfigSpaceAnalysisTest, Test2) {
   expected.col(2) << -sqrt(3.) / 2., 0.0, sqrt(3.) / 6., 0.0, sqrt(3.) / 6.,
       0.0, sqrt(3.) / 6., 0.0;
   expected.col(3) << 0.5, 0.0, 0.5, 0.0, 0.5, 0.0, 0.5, 0.0;
-  EXPECT_TRUE(almost_equal(basis, expected));
+  expect_same_basis_vectors(basis, expected);
 }
 
 TEST_F(ConfigSpaceAnalysisTest, Test3) {


### PR DESCRIPTION
- Adds Configuration.to_structure and Configuration.from_structure
- Adds ConfigurationWithProperties.to_structure and ConfigurationWithProperties.from_structure
- Add Python tests for Configuration and Structure conversions
- Bug fixes in config::FromIsotropicAtomicStructure
- Enable config::FromIsotropicAtomicStructure to read Structure strain from all strain metrics (previously only Ustrain was read)
- Create config::ToAtomicStructure class for basic Configuration to SimpleStructure conversions
- Prevent conversions from float to int for integer arrays in libcasm.configuration